### PR TITLE
Update exit code default to 0

### DIFF
--- a/empty.wdl
+++ b/empty.wdl
@@ -3,7 +3,7 @@ version 1.0
 workflow empty {
   input {
     File dummyInput
-    Int exitCode
+    Int exitCode = 0
     Int n = 10
   }
   parameter_meta {


### PR DESCRIPTION
In vidarrtest-regression.json.in, the description mentions that the default should be 0: "Log the default number of lines (10) to stderr and default exit (code=0)"